### PR TITLE
Documentation on Session Sharing

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -21,7 +21,7 @@ DEPENDENCIES:
   - Sourcery (= 0.17.0)
 
 SPEC REPOS:
-  https://cdn.cocoapods.org/:
+  trunk:
     - Alamofire
     - Moya
     - Nimble
@@ -44,6 +44,6 @@ SPEC CHECKSUMS:
   Sakai: c619aa7a0451520079f12ae28756b3799878f2b3
   Sourcery: 3ed61be7c8a1218fce349266139379dba477efe0
 
-PODFILE CHECKSUM: 20c025e7dfee2e108ea5691c02784ae9b712bef5
+PODFILE CHECKSUM: ba6398a145f7e9499701056bc849528689fd0720
 
 COCOAPODS: 1.9.1

--- a/Example/Sakai-Example.xcodeproj/project.pbxproj
+++ b/Example/Sakai-Example.xcodeproj/project.pbxproj
@@ -187,8 +187,8 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 222DA27E20B1B05700A7A914 /* Build configuration list for PBXNativeTarget "Tests" */;
 			buildPhases = (
-				2281065720B5D213003DC627 /* Generated Configuration (Sourcery) */,
 				FA2D71FAFF23736F6A177845 /* [CP] Check Pods Manifest.lock */,
+				2281065720B5D213003DC627 /* Generated Configuration (Sourcery) */,
 				222DA27320B1B05700A7A914 /* Sources */,
 				222DA27420B1B05700A7A914 /* Frameworks */,
 				222DA27520B1B05700A7A914 /* Resources */,

--- a/Example/Tests/Session/SessionTests.swift
+++ b/Example/Tests/Session/SessionTests.swift
@@ -8,6 +8,7 @@
 import Quick
 import Nimble
 import Sakai
+import Alamofire
 
 class SessionTests: QuickSpec {
 
@@ -32,23 +33,22 @@ class SessionTests: QuickSpec {
                     })
                 }
             }
-/*
+
             context("if the username or password is incorrect") {
                 it("fails to log a user in") {
-                    waitUntil(timeout: 10) { done in
+                    waitUntil(timeout: 20) { done in
                         let configuration = SakaiConfiguration(baseURL: SakaiTestConfiguration.pass.baseURL)
-                        Sakai.shared.start(configuration: configuration,
+                        SakaiAPIClient.shared.start(configuration: configuration,
                                            username: SakaiTestConfiguration.fail.username,
                                            password: SakaiTestConfiguration.fail.password)
-                        Sakai.shared.network.loginUser(username: SakaiTestConfiguration.fail.username, password: SakaiTestConfiguration.fail.password, completion: { (sessionResult) in
-                            expect(sessionResult.error).toNot(beNil())
-                            expect(sessionResult.result).to(beNil())
+                        SakaiAPIClient.shared.session.loginUser(username: SakaiTestConfiguration.fail.username, password: SakaiTestConfiguration.fail.password, completion: { (sessionResult) in
+                            expect(sessionResult.result.error).toNot(beNil())
+                            expect(sessionResult.result.value).to(beNil())
                             done()
                         })
                     }
                 }
             }
- */
         }
     }
 }

--- a/Example/Tests/Session/SessionTests.swift
+++ b/Example/Tests/Session/SessionTests.swift
@@ -8,7 +8,6 @@
 import Quick
 import Nimble
 import Sakai
-import Alamofire
 
 class SessionTests: QuickSpec {
 

--- a/README.md
+++ b/README.md
@@ -61,9 +61,9 @@ export SAKAI_TEST_SITE_ID=a-test-site-id
 export SAKAI_TEST_ANNOUNCEMENT_ID=a-test-announcement-id-the-user-can-access
 ```
 
-## Example
+## Examples
 
-Examples coming soon. Please refer to the test suite for end-to-end integration tests.
+- [Sharing a session to a WKWebView](docs/sessions.md)
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Sakai-iOS provides an easy way to build out a [Sakai LMS](https://github.com/sak
 ## How to use Sakai-iOS
 Initialize the Sakai instance with the instance configuration and a login details.
 ```swift
-let configuration = SakaiConfiguration(baseURL: URL(string: "https://example-sakai.com/direct")!)
+let configuration = SakaiConfiguration(baseURL: URL(string: "https://example-sakai.com")!)
 Sakai.shared.start(
     configuration: configuration,
     username: "STUDENT001",
@@ -54,7 +54,7 @@ You will be able to run the example project's test suite in order to test compat
 The variables which the tests use are taken from environmental variables from the machine. Ensure you set the following environmental variables in the environment you run the tests in.
 
 ```bash
-export SAKAI_TEST_BASE_URL=https://example-instance.com/direct
+export SAKAI_TEST_BASE_URL=https://example-instance.com
 export SAKAI_TEST_USERNAME=STUDENT001
 export SAKAI_TEST_PASSWORD=password
 export SAKAI_TEST_SITE_ID=a-test-site-id
@@ -68,7 +68,7 @@ Examples coming soon. Please refer to the test suite for end-to-end integration 
 ## Requirements
 
 - Swift 5
-- Tested on Sakai 11,12 & 19
+- Tested on Sakai 11, 12 & 19
 
 ## Installation
 

--- a/Sakai/API/SakaiProvider.swift
+++ b/Sakai/API/SakaiProvider.swift
@@ -17,7 +17,6 @@ private extension String {
 public let sakaiProvider = MoyaProvider<SakaiAPI>(plugins: [SakaiAPINetworkPlugin(), SakaiAPICachePlugin()])
 
 public enum SakaiAPI {
-    case legacyLogin(String, String)
     case session(String, String)
     case sessionCurrent
 
@@ -43,17 +42,9 @@ extension SakaiAPI: CachePolicyGettable {
 
 extension SakaiAPI: TargetType {
     public var headers: [String : String]? {
-        switch self {
-        case .legacyLogin:
-            return [
-                "Content-Type": "application/x-www-form-urlencoded",
-                "Pragma": "no-cache",
-                "User-Agent": "com.sakai.ios/\(RequestHelper.getFrameworkVersion())"]
-        default:
-            return [
-            "Pragma": "no-cache",
-            "User-Agent": "com.sakai.ios/\(RequestHelper.getFrameworkVersion())"]
-        }
+        return [
+        "Pragma": "no-cache",
+        "User-Agent": "com.sakai.ios/\(RequestHelper.getFrameworkVersion())"]
     }
 
     public var baseURL: URL {
@@ -67,8 +58,6 @@ extension SakaiAPI: TargetType {
 
     public var path: String {
         switch self {
-        case .legacyLogin:
-            return "/portal/xlogin"
         case .session:
             return "/direct/session"
         case .sessionCurrent:
@@ -100,7 +89,7 @@ extension SakaiAPI: TargetType {
 
     public var method: Moya.Method {
         switch self {
-        case .session, .legacyLogin:
+        case .session:
             return .post
         default:
             return .get
@@ -109,8 +98,6 @@ extension SakaiAPI: TargetType {
 
     public var task: Task {
         switch self {
-        case .legacyLogin(let username, let password):
-            return .requestParameters(parameters: ["eid" : username, "pw" : password], encoding: URLEncoding.httpBody)
         case .session(let username, let password):
             return .requestParameters(parameters: ["_username" : username, "_password" : password], encoding: URLEncoding.default)
         case .announcementsUser:

--- a/Sakai/API/SakaiProvider.swift
+++ b/Sakai/API/SakaiProvider.swift
@@ -110,7 +110,7 @@ extension SakaiAPI: TargetType {
     public var task: Task {
         switch self {
         case .legacyLogin(let username, let password):
-            return .requestParameters(parameters: ["eid" : username, "pw" : password], encoding: URLEncoding.default)
+            return .requestParameters(parameters: ["eid" : username, "pw" : password], encoding: URLEncoding.httpBody)
         case .session(let username, let password):
             return .requestParameters(parameters: ["_username" : username, "_password" : password], encoding: URLEncoding.default)
         case .announcementsUser:

--- a/Sakai/Services/SessionService.swift
+++ b/Sakai/Services/SessionService.swift
@@ -27,6 +27,9 @@ public class SessionService {
                 completion(.failure(authError))
                 return
             }
+
+            completion(.success(nil))
+            return
         }
     }
 

--- a/Sakai/Services/SessionService.swift
+++ b/Sakai/Services/SessionService.swift
@@ -52,31 +52,9 @@ public class SessionService {
                 SakaiAPIClient.shared.loggedInUserSession = sessionResult.value
                 SakaiAPIClient.shared.username = username
                 SakaiAPIClient.shared.password = password
-
-                self.legacyLoginUser(username: username, password: password) { legacyLoginResult in
-                    if let authError = legacyLoginResult.error {
-                        completion(.failure(authError))
-                        return
-                    }
-
-                    completion(sessionResult)
-                    return
-                }
-            })
-        }
-    }
-
-    public func legacyLoginUser(username: String, password: String, completion: @escaping NetworkServiceResponse<Bool>) {
-        sakaiProvider.request(.legacyLogin(username, password)) { result in
-
-            if let error = result.error {
-                let error = SakaiError.init(kind: .unknown, localizedDescription: error.localizedDescription)
-                completion(.failure(error))
+                completion(sessionResult)
                 return
-            }
-
-            completion(.success(true))
-            return
+            })
         }
     }
 

--- a/Sakai/Services/SessionService.swift
+++ b/Sakai/Services/SessionService.swift
@@ -27,16 +27,6 @@ public class SessionService {
                 completion(.failure(authError))
                 return
             }
-
-            self.legacyLoginUser(username: username, password: password) { legacyLoginResult in
-                if let authError = legacyLoginResult.error {
-                    completion(.failure(authError))
-                    return
-                }
-
-                completion(.success(nil))
-                return
-            }
         }
     }
 
@@ -59,7 +49,16 @@ public class SessionService {
                 SakaiAPIClient.shared.loggedInUserSession = sessionResult.value
                 SakaiAPIClient.shared.username = username
                 SakaiAPIClient.shared.password = password
-                completion(sessionResult)
+
+                self.legacyLoginUser(username: username, password: password) { legacyLoginResult in
+                    if let authError = legacyLoginResult.error {
+                        completion(.failure(authError))
+                        return
+                    }
+
+                    completion(sessionResult)
+                    return
+                }
             })
         }
     }

--- a/Sakai/Services/SessionService.swift
+++ b/Sakai/Services/SessionService.swift
@@ -64,26 +64,17 @@ public class SessionService {
         }
     }
 
-    
     public func legacyLoginUser(username: String, password: String, completion: @escaping NetworkServiceResponse<Bool>) {
         sakaiProvider.request(.legacyLogin(username, password)) { result in
-            guard let statusCode = result.value?.statusCode else {
-                let error = SakaiError.init(kind: .client, localizedDescription: result.error?.localizedDescription)
+
+            if let error = result.error {
+                let error = SakaiError.init(kind: .unknown, localizedDescription: error.localizedDescription)
                 completion(.failure(error))
                 return
             }
-            switch statusCode {
-            case 200:
-                let error = SakaiError.init(kind: .client, localizedDescription: nil)
-                completion(.failure(error))
-                return
-            case 301, 302:
-                completion(.success(true))
-                return
-            default:
-                let error = SakaiError.init(kind: .unknown, code: statusCode, localizedDescription: nil, title: nil, message: nil)
-                completion(.failure(error))
-            }
+
+            completion(.success(true))
+            return
         }
     }
 

--- a/docs/sessions.md
+++ b/docs/sessions.md
@@ -1,0 +1,13 @@
+## Sakai Sessions
+
+### Sharing a session with a WKWebView
+As Sakai uses cookie-based authentication instead of JWTs, you'll need to pass your cookies from the networking library (Alamofire) over to the WKWebView. This can be done by getting the Alamofire cookies and setting them on the `httpCookieStore` of the WKWebView.
+
+Before loading the request, pass the `SessionManager` cookies to the `httpCookieStore`.
+```swift
+let cookies = Alamofire.SessionManager.default.session.configuration.httpCookieStorage?.cookies  ?? []
+for cookie in cookies {
+    webview.configuration.websiteDataStore.httpCookieStore.setCookie(cookie)
+}
+loadRequest(url: url)
+```


### PR DESCRIPTION
## Context
~The Sakai API requires a user to authenticate via the portal xLogin endpoint to generate a session cookie for portal windows as well as a `direct/session` request to log in for the direct endpoints.
This adds support for the xlogin method in order for us to have authenticated web sessions~

EDIT:
This is now a documentation PR. Please see https://github.com/alihen/Sakai-iOS/pull/6#issuecomment-602018752