### PR TITLE
Make non-required fields optional

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -9,7 +9,7 @@ PODS:
   - Quick (2.2.0)
   - Require (2.0.0)
   - Result (4.1.0)
-  - Sakai (0.0.5):
+  - Sakai (0.1.0):
     - Moya (= 13.0.1)
   - Sourcery (0.17.0)
 
@@ -41,7 +41,7 @@ SPEC CHECKSUMS:
   Quick: 7fb19e13be07b5dfb3b90d4f9824c855a11af40e
   Require: f93abc18dda985f665465cf027cea7166455fb28
   Result: bd966fac789cc6c1563440b348ab2598cc24d5c7
-  Sakai: 3638e191eb88ba6bba4d07605495c49700d0be2d
+  Sakai: cabe3b8194a1d2d600866c0d8a52e23558bb111a
   Sourcery: 3ed61be7c8a1218fce349266139379dba477efe0
 
 PODFILE CHECKSUM: 3103d968b0a774988ff4ed5dafb7ba263d6804b6

--- a/Sakai/Models/Announcement.swift
+++ b/Sakai/Models/Announcement.swift
@@ -32,7 +32,7 @@ public struct SakaiAnnouncement: Codable {
 public struct SakaiAnnouncementAttachment: Codable {
     public let id : String
     public let name : String
-    public let ref : String
-    public let type : String
+    public let ref : String?
+    public let type : String?
     public let url : URL
 }

--- a/Sakai/Models/Assignment.swift
+++ b/Sakai/Models/Assignment.swift
@@ -16,36 +16,36 @@ public struct SakaiAssignmentCollection: Decodable {
 }
 
 public struct SakaiAssignmentItem: Decodable {
-    public let access: String
+    public let access: String?
     public let attachments: [SakaiAnnouncementAttachment]
     public let author: String
     public let authorLastModified: String?
-    public let closeTime: SakaiAssignmentTime
-    public let closeTimeString: String
-    public let context: String
+    public let closeTime: SakaiAssignmentTime?
+    public let closeTimeString: String?
+    public let context: String?
     public let creator: String?
-    public let dropDeadTime: SakaiAssignmentTime
-    public let dropDeadTimeString: String
-    public let dueTime: SakaiAssignmentTime
-    public let dueTimeString: String
+    public let dropDeadTime: SakaiAssignmentTime?
+    public let dropDeadTimeString: String?
+    public let dueTime: SakaiAssignmentTime?
+    public let dueTimeString: String?
     public let id: String
-    public let instructions: String
+    public let instructions: String?
     public let modelAnswerText: String?
-    public let openTime: SakaiAssignmentTime
-    public let openTimeString: String
-    public let position: Int
+    public let openTime: SakaiAssignmentTime?
+    public let openTimeString: String?
+    public let position: Int?
     public let section: String?
     public let status: String?
-    public let submissionType: String
-    public let timeCreated: SakaiAssignmentTime
-    public let timeLastModified: SakaiAssignmentTime
+    public let submissionType: String?
+    public let timeCreated: SakaiAssignmentTime?
+    public let timeLastModified: SakaiAssignmentTime?
     public let title: String
     public let allowResubmission: Bool
     public let draft: Bool
-    public let entityReference: String
+    public let entityReference: String?
     public let entityURL: URL
     public let entityID: String
-    public let entityTitle: String
+    public let entityTitle: String?
 
     enum CodingKeys: String, CodingKey {
         case access

--- a/Sakai/Models/Calendar.swift
+++ b/Sakai/Models/Calendar.swift
@@ -19,7 +19,7 @@ public struct SakaiCalendarItem: Codable {
     public let assignmentID: String?
     public let attachments: [SakaiAnnouncementAttachment]?
     public let creator: String
-    public let description: String
+    public let description: String?
     public let descriptionFormatted: String?
     public let duration: Int
     public let eventIcon: String?
@@ -28,14 +28,14 @@ public struct SakaiCalendarItem: Codable {
     public let lastTime: SakaiCalendarEvent?
     public let location: String?
     public let recurrenceRule: SakaiCalendarRecurrenceRule?
-    public let reference: String
+    public let reference: String?
     public let siteID: String
     public let siteName: String
     public let title: String
-    public let type: String
-    public let entityReference: String
+    public let type: String?
+    public let entityReference: String?
     public let entityURL: URL
-    public let entityTitle: String
+    public let entityTitle: String?
 
     enum CodingKeys: String, CodingKey {
         case assignmentID = "assignmentId"
@@ -62,14 +62,14 @@ public struct SakaiCalendarItem: Codable {
 }
 
 public struct SakaiCalendarEvent: Codable {
-    public let display: String
-    public let time: Int
+    public let display: String?
+    public let time: Int?
 }
 
 public struct SakaiCalendarRecurrenceRule: Codable {
-    public let count: Int
-    public let frequency: String
-    public let frequencyDescription: String
-    public let interval: Int
+    public let count: Int?
+    public let frequency: String?
+    public let frequencyDescription: String?
+    public let interval: Int?
     public let until: SakaiCalendarEvent?
 }

--- a/Sakai/Models/ChatChannel.swift
+++ b/Sakai/Models/ChatChannel.swift
@@ -16,16 +16,16 @@ public struct SakaiChatChannelCollection: Codable {
 }
 
 public struct SakaiChatChannel: Codable {
-    public let context: String
+    public let context: String?
     public let description: String?
     public let id: String
     public let placement: String?
     public let title: String
     public let defaultForContext: Bool
-    public let entityReference: String
+    public let entityReference: String?
     public let entityURL: URL
     public let entityID: String
-    public let entityTitle: String
+    public let entityTitle: String?
 
     enum CodingKeys: String, CodingKey {
         case context

--- a/Sakai/Models/ChatMessage.swift
+++ b/Sakai/Models/ChatMessage.swift
@@ -20,7 +20,7 @@ public struct SakaiChatMessage: Codable {
     public let chatChannelID: String
     public let context: String?
     public let id: String
-    public let messageDate: Int?
+    public let messageDate: Int
     public let messageDateString: String?
     public let owner: String
     public let ownerDisplayID: String

--- a/Sakai/Models/ChatMessage.swift
+++ b/Sakai/Models/ChatMessage.swift
@@ -18,9 +18,9 @@ public struct SakaiChatMessageCollection: Codable {
 public struct SakaiChatMessage: Codable {
     public let body: String
     public let chatChannelID: String
-    public let context: String
+    public let context: String?
     public let id: String
-    public let messageDate: Int
+    public let messageDate: Int?
     public let messageDateString: String?
     public let owner: String
     public let ownerDisplayID: String
@@ -28,7 +28,7 @@ public struct SakaiChatMessage: Codable {
     public let removeable: Bool
     public let entityReference: String
     public let entityURL: URL
-    public let entityID: String
+    public let entityID: String?
     public var avatarPath: String {
         get {
             return "/direct/profile/\(owner)/image.jpg"

--- a/Sakai/Models/Content.swift
+++ b/Sakai/Models/Content.swift
@@ -17,19 +17,19 @@ public struct SakaiContentCollection: Decodable {
 
 public struct SakaiContent: Decodable {
     public let created: Int
-    public let creator: String
+    public let creator: String?
     public let description: String?
     public let hidden: Bool
     public let mimeType: String?
-    public let modified: Int
-    public let modifiedBy: String
+    public let modified: Int?
+    public let modifiedBy: String?
     public let name: String
-    public let priority: String
+    public let priority: String?
     public let reference: String
     public let resourceChildren: [SakaiContent]
-    public let resourceID: String
+    public let resourceID: String?
     public let size: String?
-    public let type: String
+    public let type: String?
     public let url: URL
 
     enum CodingKeys: String, CodingKey {

--- a/Sakai/Models/Session.swift
+++ b/Sakai/Models/Session.swift
@@ -13,7 +13,7 @@ public struct SakaiSession: Codable {
     public let currentTime : Int64
     public let id : String?
     public let lastAccessedTime : Int64
-    public let maxInactiveInterval : Int
+    public let maxInactiveInterval : Int?
     public let userEid : String
     public let userId : String
 }

--- a/Sakai/Models/Site.swift
+++ b/Sakai/Models/Site.swift
@@ -34,14 +34,14 @@ public struct SakaiSite: Decodable {
     public let joinable : Bool
     public let joinerRole : String?
     public let lastModified : Int64
-    public let maintainRole : String
+    public let maintainRole : String?
     public let modifiedDate : Int64
     //public let modifiedTime : [String : Any]?
     public let owner : String
     public let providerGroupId : String?
     public let pubView: Bool
     public let published : Bool
-    public let reference : String
+    public let reference : String?
     public let shortDescription : String?
     //public let siteGroups : [String : Any]?
     //publiclet siteOwner : [String : Any]?
@@ -50,6 +50,6 @@ public struct SakaiSite: Decodable {
     public let softlyDeleted : Bool
     //public let softlyDeletedDate : Date?
     public let title : String
-    public let type : String
-    public let userRoles : [String]
+    public let type : String?
+    public let userRoles : [String]?
 }

--- a/Sakai/Models/User.swift
+++ b/Sakai/Models/User.swift
@@ -13,5 +13,5 @@ public struct SakaiUser: Codable {
     public let email: String?
     public let userEid : String
     public let userId : String
-    public let type: String
+    public let type: String?
 }


### PR DESCRIPTION
## Context

Decoding can sometimes fail for some instances if values of non-optional fields aren't set. Non-required fields should therefore be optional to make decoding more resilient.