### PR TITLE
Improve Site Requests

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -11,7 +11,9 @@ PODS:
   - Result (4.1.0)
   - Sakai (0.1.0):
     - Moya (= 13.0.1)
+    - SwiftSoup (= 2.3.2)
   - Sourcery (0.17.0)
+  - SwiftSoup (2.3.2)
 
 DEPENDENCIES:
   - Nimble (= 8.0.5)
@@ -29,6 +31,7 @@ SPEC REPOS:
     - Require
     - Result
     - Sourcery
+    - SwiftSoup
 
 EXTERNAL SOURCES:
   Sakai:
@@ -41,8 +44,9 @@ SPEC CHECKSUMS:
   Quick: 7fb19e13be07b5dfb3b90d4f9824c855a11af40e
   Require: f93abc18dda985f665465cf027cea7166455fb28
   Result: bd966fac789cc6c1563440b348ab2598cc24d5c7
-  Sakai: cabe3b8194a1d2d600866c0d8a52e23558bb111a
+  Sakai: 2ef8280dcf5ad68a89b825457184f9e89dd0a144
   Sourcery: 3ed61be7c8a1218fce349266139379dba477efe0
+  SwiftSoup: f97bc4e988c7729d6457f9642f974c617a6e2510
 
 PODFILE CHECKSUM: 3103d968b0a774988ff4ed5dafb7ba263d6804b6
 

--- a/Example/Tests/Site/SiteTests.swift
+++ b/Example/Tests/Site/SiteTests.swift
@@ -30,19 +30,12 @@ class SiteTest: QuickSpec {
                         expect(siteResult.error).to(beNil())
                         expect(siteResult.value?.id).toNot(beNil())
                         expect(siteResult.value?.sitePages).toNot(beEmpty())
-                        guard let sitePage = siteResult.value?.sitePages?.first else {
-                            fail("Unable to get site page")
-                            done()
-                            return
-                        }
-
-                        expect(sitePage.pagePath).to(equal("/portal/page/\(sitePage.id)"))
                         done()
                     })
                 }
             }
 
-            context("if the site id does note exist") {
+            context("if the site id does not exist") {
                 it("fails to return a single site by ID") {
                     waitUntil(timeout: 20) { done in
                         SakaiAPIClient.shared.site.getSite(withID: SakaiTestConfiguration.fail.siteId, completion: { (siteResult) in
@@ -53,14 +46,38 @@ class SiteTest: QuickSpec {
                     }
                 }
             }
+            
 
-            it("returns all the sites") {
+            it("returns all the sites via parsing HTML") {
                 waitUntil(timeout: 50) { done in
-                    SakaiAPIClient.shared.site.getAllSites(completion: { (siteResults) in
+                    SakaiAPIClient.shared.site.getAllSitesViaPortal(completion: { (siteResults) in
                         expect(siteResults.error).to(beNil())
                         expect(siteResults.value).toNot(beEmpty())
                         done()
                     })
+                }
+            }
+
+            it("returns all the sites via the direct endpoint") {
+                waitUntil(timeout: 50) { done in
+                    SakaiAPIClient.shared.site.getAllSitesViaDirect(completion: { (siteResults) in
+                        expect(siteResults.error).to(beNil())
+                        expect(siteResults.value).toNot(beEmpty())
+                        done()
+                    })
+                }
+            }
+
+            it("returns the site pages for a specified site") {
+                waitUntil(timeout: 50) { done in
+                    SakaiAPIClient.shared.site.getSitePages(siteId: SakaiTestConfiguration.pass.siteId) { result in
+                        expect(result.error).to(beNil())
+                        expect(result.value).toNot(beNil())
+                        expect(result.value).toNot(beEmpty())
+                        expect(result.value?.first?.tools).toNot(beEmpty())
+                        expect(result.value?.first?.tools?.first?.toolPath).toNot(beNil())
+                        done()
+                    }
                 }
             }
         }

--- a/Sakai.podspec
+++ b/Sakai.podspec
@@ -24,6 +24,7 @@ Sakai-iOS provides an easy way to build out a Sakai LMS learning experience with
   s.source_files  = "Sakai/**/*.{swift}"
   
   s.dependency "Moya", "13.0.1"
+  s.dependency "SwiftSoup", "2.3.2"
   s.swift_version = "5.0"
 
 end

--- a/Sakai/API/SakaiProvider.swift
+++ b/Sakai/API/SakaiProvider.swift
@@ -18,6 +18,7 @@ public var sakaiProvider = MoyaProvider<SakaiAPI>(manager: SakaiAPIAlamofireMana
 
 public enum SakaiAPI {
     case session(String, String)
+    case legacyLogin(String, String)
     case sessionCurrent
     case userCurrent
     case userProfile(String)
@@ -25,7 +26,9 @@ public enum SakaiAPI {
     case announcementsSite(String)
     case announcementsUser(String)
     case sites
+    case sitesViaPortal
     case site(String)
+    case sitePages(String)
     case contentSite(String, String?) // Site ID, Path
     case contentMy
     case contentUser(String)
@@ -70,6 +73,8 @@ extension SakaiAPI: TargetType {
         switch self {
         case .session:
             return "/direct/session"
+        case .legacyLogin:
+            return "/portal/xlogin"
         case .sessionCurrent:
             return "/direct/session/current.json"
         case .userCurrent:
@@ -82,10 +87,14 @@ extension SakaiAPI: TargetType {
             return "/direct/announcement/site/\(siteId).json"
         case .announcementsUser(let userId):
             return "/direct/announcement/\(userId).json"
+        case .sitesViaPortal:
+            return "/portal"
         case .sites:
             return "/direct/site.json"
         case .site(let id):
             return "/direct/site/\(id).json"
+        case .sitePages(let id):
+            return "/direct/site/\(id)/pages.json"
         case .contentSite(let id, let path):
             if let path = path {
                 return "/direct/content/resources/\(id)/\(path).json"
@@ -118,7 +127,7 @@ extension SakaiAPI: TargetType {
 
     public var method: Moya.Method {
         switch self {
-        case .session, .postChatMessage:
+        case .session, .postChatMessage, .legacyLogin:
             return .post
         default:
             return .get
@@ -129,8 +138,12 @@ extension SakaiAPI: TargetType {
         switch self {
         case .session(let username, let password):
             return .requestParameters(parameters: ["_username" : username, "_password" : password], encoding: URLEncoding.default)
+        case .legacyLogin(let username, let password):
+            return .requestParameters(parameters: ["eid" : username, "pw" : password], encoding: URLEncoding.httpBody)
         case .announcementsUser:
             return .requestParameters(parameters: ["n": "100"], encoding: URLEncoding.default)
+        case .sites:
+            return .requestParameters(parameters: ["_limit": "40"], encoding: URLEncoding.default)
         case .chatChannels(let siteId):
             return .requestParameters(parameters: ["siteId": siteId], encoding: URLEncoding.default)
         case .chatMessages(let channelId):

--- a/Sakai/API/SakaiProvider.swift
+++ b/Sakai/API/SakaiProvider.swift
@@ -138,6 +138,8 @@ extension SakaiAPI: TargetType {
         switch self {
         case .session(let username, let password):
             return .requestParameters(parameters: ["_username" : username, "_password" : password], encoding: URLEncoding.default)
+        case .announcementsUser:
+            return .requestParameters(parameters: ["n": "30", "d": "90"], encoding: URLEncoding.default)
         case .legacyLogin(let username, let password):
             return .requestParameters(parameters: ["eid" : username, "pw" : password], encoding: URLEncoding.httpBody)
         case .sites:

--- a/Sakai/API/SakaiProvider.swift
+++ b/Sakai/API/SakaiProvider.swift
@@ -140,8 +140,6 @@ extension SakaiAPI: TargetType {
             return .requestParameters(parameters: ["_username" : username, "_password" : password], encoding: URLEncoding.default)
         case .legacyLogin(let username, let password):
             return .requestParameters(parameters: ["eid" : username, "pw" : password], encoding: URLEncoding.httpBody)
-        case .announcementsUser:
-            return .requestParameters(parameters: ["n": "100"], encoding: URLEncoding.default)
         case .sites:
             return .requestParameters(parameters: ["_limit": "40"], encoding: URLEncoding.default)
         case .chatChannels(let siteId):

--- a/Sakai/Classes/PortalHTMLParser.swift
+++ b/Sakai/Classes/PortalHTMLParser.swift
@@ -1,0 +1,40 @@
+//
+//  PortalHTMLParser.swift
+//  Sakai
+//
+//  Created by Alastair Hendricks on 2020/05/04.
+//
+
+import Foundation
+import SwiftSoup
+
+class PortalHTMLParser {
+    class func parsePortalHTML(html: String,
+                               sectionSelector: String,
+                               termSelector: String,
+                               siteSelector: String,
+                               dataSelector: String) -> [SakaiPortalSiteSection] {
+        var sakaiPortalSections: [SakaiPortalSiteSection] = []
+        do {
+            let doc: Document = try SwiftSoup.parse(html)
+            let userCourseSections: Elements = try doc.select(sectionSelector)
+            for courseSection in userCourseSections.array() {
+                let termString = try courseSection.select(termSelector).text()
+                let courseData: Elements = try courseSection.select(siteSelector)
+                var sakaiPortalCourses: [SakaiPortalSite] = []
+                for course in courseData.array() {
+                    let courseTitle = try course.text()
+                    let courseId = try course.select("a[\(dataSelector)]").attr(dataSelector)
+                    let site = SakaiPortalSite(id: courseId, title: courseTitle)
+                    sakaiPortalCourses.append(site)
+                }
+                let section = SakaiPortalSiteSection(term: termString, sites: sakaiPortalCourses)
+                sakaiPortalSections.append(section)
+            }
+
+            return sakaiPortalSections
+        } catch {
+            return sakaiPortalSections
+        }
+    }
+}

--- a/Sakai/Classes/PortalHTMLParser.swift
+++ b/Sakai/Classes/PortalHTMLParser.swift
@@ -26,7 +26,9 @@ class PortalHTMLParser {
                     let courseTitle = try course.text()
                     let courseId = try course.select("a[\(dataSelector)]").attr(dataSelector)
                     let site = SakaiPortalSite(id: courseId, title: courseTitle)
-                    sakaiPortalCourses.append(site)
+                    if !courseId.isEmpty {
+                        sakaiPortalCourses.append(site)
+                    }
                 }
                 let section = SakaiPortalSiteSection(term: termString, sites: sakaiPortalCourses)
                 sakaiPortalSections.append(section)

--- a/Sakai/Models/Site.swift
+++ b/Sakai/Models/Site.swift
@@ -53,3 +53,24 @@ public struct SakaiSite: Decodable {
     public let type : String?
     public let userRoles : [String]?
 }
+
+// A revised approach to handling Sites, using the Portal HTML
+public struct SakaiPortalSiteSection: Decodable {
+    public let term: String
+    public let sites: [SakaiPortalSite]
+
+    init(term: String, sites: [SakaiPortalSite]) {
+        self.term = term
+        self.sites = sites
+    }
+}
+
+public struct SakaiPortalSite: Decodable {
+    public let id: String
+    public let title: String
+
+    init(id: String, title: String) {
+        self.id = id
+        self.title = title
+    }
+}

--- a/Sakai/Models/SitePage.swift
+++ b/Sakai/Models/SitePage.swift
@@ -39,7 +39,7 @@ public struct SitePageTool: Decodable {
     public let url : URL
     public var toolPath: String {
         get {
-            return "/portal/tool/\(id)/main"
+            return "/portal/tool-reset/\(id)"
         }
     }
 

--- a/Sakai/Models/SitePage.swift
+++ b/Sakai/Models/SitePage.swift
@@ -9,37 +9,47 @@ import Foundation
 
 public struct SitePage: Decodable {
     public let id: String
-    public let layout: Int?
-    public let activeEdit: Bool
     public let siteID: String
     public let position: Int?
-    public let popUp: Bool?
-    public let homePage: Bool?
     public let url: URL
     public let title: String
     public let skin: String?
     public let layoutTitle: String?
-    public let reference: String?
-    public let titleCustom: Bool?
-    public var pagePath: String {
-        get {
-            return "/portal/page/\(id)"
-        }
-    }
+    public let tools: [SitePageTool]?
 
     enum CodingKeys: String, CodingKey {
         case id
-        case layout
-        case activeEdit
         case siteID = "siteId"
         case position
-        case popUp
-        case homePage
         case url
         case title
         case skin
         case layoutTitle
-        case reference
-        case titleCustom
+        case tools
+    }
+}
+
+public struct SitePageTool: Decodable {
+    public let toolId: String
+    public let pageOrder: Int?
+    public let siteId: String
+    public let id: String
+    public let title: String
+    public let pageId: String
+    public let url : URL
+    public var toolPath: String {
+        get {
+            return "/portal/tool/\(id)/main"
+        }
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case toolId
+        case pageOrder
+        case siteId
+        case id
+        case title
+        case pageId
+        case url
     }
 }

--- a/Sakai/Services/SessionService.swift
+++ b/Sakai/Services/SessionService.swift
@@ -58,6 +58,20 @@ public class SessionService {
         }
     }
 
+    public func legacyLoginUser(username: String, password: String, completion: @escaping NetworkServiceResponse<Bool>) {
+        sakaiProvider.request(.legacyLogin(username, password)) { result in
+
+            if let error = result.error {
+                let error = SakaiError.init(kind: .unknown, localizedDescription: error.localizedDescription)
+                completion(.failure(error))
+                return
+            }
+
+            completion(.success(true))
+            return
+        }
+    }
+
     public func getSession(completion: @escaping NetworkServiceResponse<SakaiSession>) {
         sakaiProvider.request(.sessionCurrent) { result in
             completion(ResponseHelper.handle(SakaiSession.self, result: result))

--- a/Sakai/Services/SiteService.swift
+++ b/Sakai/Services/SiteService.swift
@@ -22,6 +22,65 @@ public class SiteService {
         }
     }
 
+    public func getAllSitesViaPortal(completion: @escaping NetworkServiceResponse<[SakaiPortalSiteSection]>) {
+        SakaiAPIClient.shared.session.prepAuthedRoute { (sessionResult) in
+            if let authError = sessionResult.error {
+                completion(.failure(authError))
+                return
+            }
+        }
+
+        guard
+            let username = SakaiAPIClient.shared.username,
+            let password = SakaiAPIClient.shared.password else {
+                completion(.failure(SakaiError.init(kind: .unknown, localizedDescription: nil)))
+                return
+        }
+
+
+        SakaiAPIClient.shared.session.legacyLoginUser(username: username, password: password) { loginResult in
+            if loginResult.value == true {
+                sakaiProvider.request(.sitesViaPortal) { result in
+                    do {
+                        guard let htmlString = try result.value?.mapString() else {
+                            return
+                        }
+                        let sections = PortalHTMLParser.parsePortalHTML(
+                            html: htmlString,
+                            sectionSelector: "#otherSitesCategorWrap > div.moresites-left-col",
+                            termSelector: "h3",
+                            siteSelector: ".otherSitesCategorList > li",
+                            dataSelector: "data-site-id")
+                        completion(.success(sections))
+                    }
+                    catch {
+                        completion(.failure(SakaiError.init(kind: .unknown, localizedDescription: error.localizedDescription)))
+                    }
+                }
+            } else {
+                completion(.failure(SakaiError.init(kind: .unknown, localizedDescription: "Unable to login via xlogin")))
+            }
+        }
+    }
+
+    public func getAllSitesViaDirect(completion: @escaping NetworkServiceResponse<[SakaiPortalSiteSection]>) {
+        self.getAllSites { siteResult in
+            if let error = siteResult.error {
+                completion(.failure(error))
+                return
+            }
+
+            let sites = siteResult.value ?? []
+            var sectionSites: [SakaiPortalSite] = []
+            for site in sites {
+                let portalSite = SakaiPortalSite(id: site.id, title: site.title)
+                sectionSites.append(portalSite)
+            }
+            let result = [SakaiPortalSiteSection(term: "All Sites", sites: sectionSites)]
+            completion(.success(result))
+        }
+    }
+
     public func getAllSites(completion: @escaping NetworkServiceResponse<[SakaiSite]>) {
         SakaiAPIClient.shared.session.prepAuthedRoute { (sessionResult) in
             if let authError = sessionResult.error {
@@ -48,6 +107,19 @@ public class SiteService {
                 completion(.failure(moyaErrors))
                 return
             }
+        }
+    }
+
+    public func getSitePages(siteId: String, completion: @escaping NetworkServiceResponse<[SitePage]> ) {
+        SakaiAPIClient.shared.session.prepAuthedRoute { (sessionResult) in
+            if let authError = sessionResult.error {
+                completion(.failure(authError))
+                return
+            }
+        }
+
+        sakaiProvider.request(.sitePages(siteId)) { result in
+            completion(ResponseHelper.handle([SitePage].self, result: result))
         }
     }
 }

--- a/Sakai/Services/SiteService.swift
+++ b/Sakai/Services/SiteService.swift
@@ -64,11 +64,15 @@ public class SiteService {
                         completion(.success(result))
                     }
                     catch {
-                        completion(.failure(SakaiError.init(kind: .unknown, localizedDescription: error.localizedDescription)))
+                        self.getAllSitesViaDirect { result in
+                            completion(result)
+                        }
                     }
                 }
             } else {
-                completion(.failure(SakaiError.init(kind: .unknown, localizedDescription: "Unable to login via xlogin")))
+                self.getAllSitesViaDirect { result in
+                    completion(result)
+                }
             }
         }
     }

--- a/Sakai/Services/SiteService.swift
+++ b/Sakai/Services/SiteService.swift
@@ -45,13 +45,23 @@ public class SiteService {
                         guard let htmlString = try result.value?.mapString() else {
                             return
                         }
-                        let sections = PortalHTMLParser.parsePortalHTML(
+                        let siteSections = PortalHTMLParser.parsePortalHTML(
                             html: htmlString,
                             sectionSelector: "#otherSitesCategorWrap > div.moresites-left-col",
                             termSelector: "h3",
                             siteSelector: ".otherSitesCategorList > li",
                             dataSelector: "data-site-id")
-                        completion(.success(sections))
+                        let projectSections = PortalHTMLParser.parsePortalHTML(
+                        html: htmlString,
+                        sectionSelector: "#otherSitesCategorWrap > div.moresites-right-col",
+                        termSelector: "h3",
+                        siteSelector: ".otherSitesCategorList > li",
+                        dataSelector: "data-site-id")
+
+                        var result = siteSections
+                        result.append(contentsOf: projectSections)
+
+                        completion(.success(result))
                     }
                     catch {
                         completion(.failure(SakaiError.init(kind: .unknown, localizedDescription: error.localizedDescription)))


### PR DESCRIPTION
- Fetch Sites using HTML parsing instead of the `/direct/sites.json` endpoint. Fetching HTML is quicker in most cases and we're able to keep track of the term associated to the site.
- Introduce get site pages via the direct API - needed if we're moving away from `/direct/sites.json`
- Refactor Site Pages Decodable, and introduce Tools struct.